### PR TITLE
Add quotation to the verify_certificate default value

### DIFF
--- a/jobs/racoon/spec
+++ b/jobs/racoon/spec
@@ -86,4 +86,4 @@ properties:
 
   racoon.verify_certificate:
     description: "on or off"
-    default: on
+    default: 'on'


### PR DESCRIPTION
## What

Bosh compiler interprets this value as `true`, which causes the error.
The quotation fixes the issue in our case.

## How to review

Omit setting `verify_certificate` while configuring `instance_groups`/`jobs` `properties`.