### PR TITLE
Disable stats logging

### DIFF
--- a/packages/racoon/packaging
+++ b/packages/racoon/packaging
@@ -34,7 +34,7 @@ CFLAGS=-fno-strict-aliasing ./configure  \
 --enable-natt \
 --enable-dpd \
 --disable-ipv6 \
---enable-stats \
+--disable-stats \
 --enable-hybrid \
 --disable-security-context \
 --with-kernel-headers=/usr/include/ \


### PR DESCRIPTION
When racoon is compiled with the `--enable-stats` option it logs timing
information every time an algorithm function is called:

    Mar 16 14:00:12 localhost racoon: alg_oakley_hmacdef_one(hmac_sha2_256 size=36): 0.000007
    Mar 16 14:00:12 localhost racoon: alg_oakley_encdef_encrypt(aes klen=128 size=80): 0.000006
    Mar 16 14:00:12 localhost racoon: alg_oakley_encdef_decrypt(aes klen=128 size=80): 0.000004
    Mar 16 14:00:12 localhost racoon: alg_oakley_hmacdef_one(hmac_sha2_256 size=36): 0.000006
    Mar 16 14:00:12 localhost racoon: alg_oakley_hmacdef_one(hmac_sha2_256 size=36): 0.000004
    Mar 16 14:00:12 localhost racoon: alg_oakley_encdef_encrypt(aes klen=128 size=80): 0.000003
    Mar 16 14:00:12 localhost racoon: alg_oakley_encdef_decrypt(aes klen=128 size=80): 0.000003
    Mar 16 14:00:12 localhost racoon: alg_oakley_hmacdef_one(hmac_sha2_256 size=36): 0.000006
    Mar 16 14:00:13 localhost racoon: alg_oakley_hmacdef_one(hmac_sha2_256 size=36): 0.000008
    Mar 16 14:00:13 localhost racoon: alg_oakley_encdef_encrypt(aes klen=128 size=80): 0.000007
    Mar 16 14:00:13 localhost racoon: alg_oakley_encdef_decrypt(aes klen=128 size=80): 0.000004

We want to disable this feature because it is incredibly noisy and not very
useful. Omitting the `--enable-stats` option would be sufficient, but I've
changed it to `--disable-stats` in order to be explicit that we don't want
this.

Fixes #4