### PR TITLE
Fix compilation on ubuntu xenial

### DIFF
--- a/packages/racoon/packaging
+++ b/packages/racoon/packaging
@@ -34,7 +34,6 @@ CFLAGS=-fno-strict-aliasing ./configure  \
 --enable-natt \
 --enable-dpd \
 --disable-ipv6 \
---enable-hybrid \
 --disable-security-context \
 --with-kernel-headers=/usr/include/ \
 --prefix=${PKG_DIR} \


### PR DESCRIPTION
Compilation of ipsec-tools-0.8.2 on ubuntu-xenial failed with an error

isakmp_xauth.c: In function 'xauth_reply':
isakmp_xauth.c:375:1: error: type of 'res' defaults to 'int' [-Werror=implicit-int]
 xauth_reply(iph1, port, id, res)

Removing the --enable-hybrid compilation flag fixes this.